### PR TITLE
feat: 쿠키 기반 인증 지원 추가 및 로그인 워크플로우 개선

### DIFF
--- a/src/main/java/com/recorday/recorday/auth/component/code/RandomVerificationCodeGenerator.java
+++ b/src/main/java/com/recorday/recorday/auth/component/code/RandomVerificationCodeGenerator.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class RandomVerificationCodeGenerator implements VerificationCodeGenerator {
 
-	private static final String ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	private static final String ALPHANUMERIC = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 	private static final int CODE_LENGTH = 6;
 	private final SecureRandom secureRandom = new SecureRandom();
 

--- a/src/main/java/com/recorday/recorday/auth/controller/LocalAuthController.java
+++ b/src/main/java/com/recorday/recorday/auth/controller/LocalAuthController.java
@@ -20,6 +20,8 @@ import com.recorday.recorday.auth.local.dto.request.LocalRegisterRequest;
 import com.recorday.recorday.auth.local.dto.request.LocalResetPasswordRequest;
 import com.recorday.recorday.auth.local.dto.request.LocalVerifyPasswordRequest;
 import com.recorday.recorday.auth.local.dto.response.EmailAuthVerifyResponse;
+import com.recorday.recorday.auth.local.dto.response.LoginResponse;
+import com.recorday.recorday.auth.local.dto.response.LoginResult;
 import com.recorday.recorday.auth.local.service.LocalLoginService;
 import com.recorday.recorday.auth.local.service.LocalUserAuthService;
 import com.recorday.recorday.auth.local.service.PasswordService;
@@ -45,11 +47,14 @@ public class LocalAuthController {
 	private final UserExitService userExitService;
 	private final PasswordService passwordService;
 
-	@Operation(summary = "이메일 로그인", description = "등록된 이메일과 비밀번호로 로그인하여 Access/Refresh 토큰을 발급받습니다.")
+	@Operation(summary = "이메일 로그인", description = "등록된 이메일과 비밀번호로 로그인하여 Access/Refresh 토큰을 쿠키로 발급받습니다.")
 	@PostMapping("/recorday/login")
-	public ResponseEntity<Response<TokenResponse>> login(@RequestBody @Valid LocalLoginRequest request) {
-		TokenResponse tokenResponse = localLoginService.login(request);
-		return Response.ok(tokenResponse).toResponseEntity();
+	public ResponseEntity<Response<LoginResponse>> login(@RequestBody @Valid LocalLoginRequest request) {
+		LoginResult result = localLoginService.login(request);
+
+		LoginResponse responseBody = new LoginResponse(result.userStatus());
+
+		return Response.ok(responseBody).toResponseEntity(result.cookies());
 	}
 
 	@Operation(summary = "이메일 회원가입", description = "새로운 사용자를 등록합니다.")

--- a/src/main/java/com/recorday/recorday/auth/jwt/controller/RefreshTokenController.java
+++ b/src/main/java/com/recorday/recorday/auth/jwt/controller/RefreshTokenController.java
@@ -2,6 +2,7 @@ package com.recorday.recorday.auth.jwt.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.recorday.recorday.auth.entity.CustomUserPrincipal;
+import com.recorday.recorday.auth.jwt.dto.AuthTokenCookies;
 import com.recorday.recorday.auth.jwt.service.RefreshTokenService;
 import com.recorday.recorday.auth.local.dto.response.AuthTokenResponse;
 import com.recorday.recorday.util.response.Response;
@@ -26,20 +28,20 @@ public class RefreshTokenController {
 
 	private final RefreshTokenService refreshTokenService;
 
-	@Operation(summary = "토큰 재발급", description = "헤더에 포함된 Refresh Token을 검증하여 새로운 Access Token과 Refresh Token을 발급합니다.")
+	@Operation(summary = "토큰 재발급", description = "쿠키에 포함된 Refresh Token을 검증하여 새로운 Access Token과 Refresh Token을 쿠키로 발급합니다.")
 	@PostMapping("/recorday/reissue")
-	public ResponseEntity<Response<AuthTokenResponse>> reissue(
-		@Parameter(description = "리프레시 토큰 (Bearer 없이 토큰 값만 입력)", required = true, example = "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...")
-		@RequestHeader("Refresh-Token") String refreshToken
+	public ResponseEntity<Response<Void>> reissue(
+		@Parameter(description = "리프레시 토큰 쿠키", required = true)
+		@CookieValue("refreshToken") String refreshToken
 	) {
-		AuthTokenResponse tokens = refreshTokenService.reissue(refreshToken);
-		return Response.ok(tokens).toResponseEntity();
+		AuthTokenCookies tokens = refreshTokenService.reissue(refreshToken);
+		return Response.ok().toResponseEntity(tokens);
 	}
 
 	@Operation(summary = "로그아웃", description = "서버(Redis)에 저장된 해당 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다.")
 	@DeleteMapping("/recorday/logout")
 	public ResponseEntity<Response<Void>> logout(
-		@Parameter(hidden = true) // 사용자 정보는 SecurityContext에서 가져오므로 문서에서 숨김
+		@Parameter(hidden = true)
 		@AuthenticationPrincipal CustomUserPrincipal principal
 	) {
 		refreshTokenService.logout(principal.getPublicId());

--- a/src/main/java/com/recorday/recorday/auth/jwt/dto/AuthTokenCookies.java
+++ b/src/main/java/com/recorday/recorday/auth/jwt/dto/AuthTokenCookies.java
@@ -1,0 +1,9 @@
+package com.recorday.recorday.auth.jwt.dto;
+
+import org.springframework.http.ResponseCookie;
+
+public record AuthTokenCookies(
+	ResponseCookie accessTokenCookie,
+	ResponseCookie refreshTokenCookie
+) {
+}

--- a/src/main/java/com/recorday/recorday/auth/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/recorday/recorday/auth/jwt/service/JwtTokenService.java
@@ -13,4 +13,6 @@ public interface JwtTokenService {
 	public String getTokenType(String token);
 
 	public long getRefreshTokenValidityMillis();
+
+	public long getAccessTokenValidityMillis();
 }

--- a/src/main/java/com/recorday/recorday/auth/jwt/service/JwtTokenServiceImpl.java
+++ b/src/main/java/com/recorday/recorday/auth/jwt/service/JwtTokenServiceImpl.java
@@ -96,4 +96,9 @@ public class JwtTokenServiceImpl implements JwtTokenService{
 	public long getRefreshTokenValidityMillis() {
 		return refreshTokenValidityMillis;
 	}
+
+	@Override
+	public long getAccessTokenValidityMillis() {
+		return accessTokenValidityMillis;
+	}
 }

--- a/src/main/java/com/recorday/recorday/auth/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/recorday/recorday/auth/jwt/service/RefreshTokenService.java
@@ -1,12 +1,13 @@
 package com.recorday.recorday.auth.jwt.service;
 
+import com.recorday.recorday.auth.jwt.dto.AuthTokenCookies;
 import com.recorday.recorday.auth.local.dto.response.AuthTokenResponse;
 
 public interface RefreshTokenService {
 
 	void saveRefreshToken(String publicId, String refreshToken);
 
-	AuthTokenResponse reissue(String refreshToken);
+	AuthTokenCookies reissue(String refreshToken);
 
 	void logout(String publicId);
 }

--- a/src/main/java/com/recorday/recorday/auth/local/dto/response/LoginResponse.java
+++ b/src/main/java/com/recorday/recorday/auth/local/dto/response/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.recorday.recorday.auth.local.dto.response;
+
+import com.recorday.recorday.user.enums.UserStatus;
+
+public record LoginResponse(
+	UserStatus userStatus
+) {
+}

--- a/src/main/java/com/recorday/recorday/auth/local/dto/response/LoginResult.java
+++ b/src/main/java/com/recorday/recorday/auth/local/dto/response/LoginResult.java
@@ -1,0 +1,10 @@
+package com.recorday.recorday.auth.local.dto.response;
+
+import com.recorday.recorday.auth.jwt.dto.AuthTokenCookies;
+import com.recorday.recorday.user.enums.UserStatus;
+
+public record LoginResult(
+	AuthTokenCookies cookies,
+	UserStatus userStatus
+) {
+}

--- a/src/main/java/com/recorday/recorday/auth/local/service/LocalLoginService.java
+++ b/src/main/java/com/recorday/recorday/auth/local/service/LocalLoginService.java
@@ -1,11 +1,10 @@
 package com.recorday.recorday.auth.local.service;
 
-import com.recorday.recorday.auth.jwt.dto.TokenResponse;
 import com.recorday.recorday.auth.local.dto.request.LocalLoginRequest;
-import com.recorday.recorday.auth.local.dto.response.AuthTokenResponse;
+import com.recorday.recorday.auth.local.dto.response.LoginResult;
 
 public interface LocalLoginService {
 
-	TokenResponse login(LocalLoginRequest request);
+	LoginResult login(LocalLoginRequest request);
 
 }

--- a/src/main/java/com/recorday/recorday/auth/local/service/mail/MailAuthCodeService.java
+++ b/src/main/java/com/recorday/recorday/auth/local/service/mail/MailAuthCodeService.java
@@ -19,7 +19,7 @@ public class MailAuthCodeService {
 	private final EmailService emailService;
 
 	private static final long VERIFICATION_TTL = 300L;
-	private static final String EMAIL_SUBJECT = "[Recorday] 이메일 인증 코드입니다.";
+	private static final String EMAIL_SUBJECT = "[Harucut] 이메일 인증 코드입니다.";
 
 	public void sendCode(String email) {
 

--- a/src/main/java/com/recorday/recorday/auth/utils/CookieUtil.java
+++ b/src/main/java/com/recorday/recorday/auth/utils/CookieUtil.java
@@ -1,0 +1,20 @@
+package com.recorday.recorday.auth.utils;
+
+import java.time.Duration;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+	public ResponseCookie createTokenCookie(String name, String value, long maxAgeMillis) {
+		return ResponseCookie.from(name, value)
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(Duration.ofMillis(maxAgeMillis))
+			.sameSite("Strict")
+			.build();
+	}
+}

--- a/src/main/java/com/recorday/recorday/util/response/Response.java
+++ b/src/main/java/com/recorday/recorday/util/response/Response.java
@@ -1,9 +1,11 @@
 package com.recorday.recorday.util.response;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.recorday.recorday.auth.jwt.dto.AuthTokenCookies;
 import com.recorday.recorday.exception.ErrorCode;
 
 import lombok.AllArgsConstructor;
@@ -51,6 +53,15 @@ public class Response<T> {
 	public ResponseEntity<Response<T>> toResponseEntity() {
 		HttpStatus httpStatus = HttpStatus.valueOf(this.status);
 		return new ResponseEntity<>(this, httpStatus);
+	}
+
+	public ResponseEntity<Response<T>> toResponseEntity(AuthTokenCookies cookies) {
+		HttpStatus httpStatus = HttpStatus.valueOf(this.status);
+
+		return ResponseEntity.status(httpStatus)
+			.header(HttpHeaders.SET_COOKIE, cookies.accessTokenCookie().toString())
+			.header(HttpHeaders.SET_COOKIE, cookies.refreshTokenCookie().toString())
+			.body(this);
 	}
 
 	public static <T> Response<T> from(ErrorCode errorCode, T data) {

--- a/src/main/resources/templates/verification-code.html
+++ b/src/main/resources/templates/verification-code.html
@@ -13,7 +13,7 @@
         <div style="padding: 28px 32px 18px 32px; text-align: center; border-bottom: 1px solid #f0f0f0;">
             <div style="display: inline-block; padding: 8px 16px; border-radius: 999px; background-color: #ecfdf7; margin-bottom: 10px;">
                 <span style="font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #00a876; font-weight: 600;">
-                    Recorday
+                    Harucut
                 </span>
             </div>
             <h1 style="margin: 4px 0 0 0; font-size: 22px; font-weight: 700; color: #222222;">
@@ -27,7 +27,7 @@
 
         <div style="padding: 28px 32px 24px 32px;">
             <p style="color: #555555; font-size: 14px; line-height: 1.7; margin: 0 0 22px 0;">
-                안녕하세요. Recorday를 이용해 주셔서 감사합니다. <br>
+                안녕하세요. Harucut을 이용해 주셔서 감사합니다. <br>
                 아래 인증 코드를 회원가입 화면에 입력하여 인증을 완료해주세요.
             </p>
 
@@ -66,13 +66,13 @@
 
             <p style="margin: 0; font-size: 13px; color: #8a8a8a; line-height: 1.6;">
                 언제나 특별한 순간을 기록할 수 있도록<br>
-                <strong style="color: #00a875;">Recorday</strong>
+                <strong style="color: #00a875;">Harucut</strong>
             </p>
         </div>
 
         <div style="border-top: 1px solid #f0f0f0; padding: 16px 32px 18px 32px; background-color: #fafafa; text-align: center;">
             <p style="margin: 0 0 4px 0; font-size: 11px; color: #aaaaaa; line-height: 1.5;">
-                &copy; 2025 Recorday. All rights reserved.
+                &copy; 2025 Harucut. All rights reserved.
             </p>
             <p style="margin: 0; font-size: 11px; color: #bbbbbb; line-height: 1.4;">
                 본 메일은 발신 전용이며 회신되지 않습니다.

--- a/src/test/java/com/recorday/recorday/auth/jwt/filter/JwtAuthenticationFilterCookieTest.java
+++ b/src/test/java/com/recorday/recorday/auth/jwt/filter/JwtAuthenticationFilterCookieTest.java
@@ -1,0 +1,115 @@
+package com.recorday.recorday.auth.jwt.filter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.recorday.recorday.auth.entity.CustomUserPrincipal;
+import com.recorday.recorday.auth.jwt.service.JwtTokenService;
+import com.recorday.recorday.auth.service.UserPrincipalLoader;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterCookieTest {
+
+	@InjectMocks
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Mock
+	private JwtTokenService jwtTokenService;
+	@Mock
+	private UserPrincipalLoader userPrincipalLoader;
+	@Mock
+	private AuthenticationEntryPoint authenticationEntryPoint;
+
+	@Mock
+	private HttpServletRequest request;
+	@Mock
+	private HttpServletResponse response;
+	@Mock
+	private FilterChain filterChain;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("쿠키에 accessToken이 있고 유효하다면 인증 객체를 생성하고 다음 필터로 진행한다")
+	void shouldAuthenticateWhenAccessTokenCookieIsValid() throws ServletException, IOException {
+		// Given
+		String validToken = "valid.jwt.token";
+		String publicId = "user-public-id";
+		Cookie accessCookie = new Cookie("accessToken", validToken);
+
+		// request.getCookies()가 accessCookie를 포함한 배열을 반환하도록 설정
+		given(request.getRequestURI()).willReturn("/api/some-endpoint");
+		given(request.getCookies()).willReturn(new Cookie[] {accessCookie});
+
+		given(jwtTokenService.getUserPublicId(validToken)).willReturn(publicId);
+
+		CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
+		given(userPrincipalLoader.loadUserByPublicId(publicId)).willReturn(principal);
+		given(principal.getAuthorities()).willReturn(null);
+
+		// When
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+		// Then
+		then(jwtTokenService).should().validateToken(validToken);
+		then(filterChain).should().doFilter(request, response);
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(principal);
+	}
+
+	@Test
+	@DisplayName("쿠키가 아예 존재하지 않으면(null) 필터 체인을 그대로 통과한다")
+	void shouldPassFilterWhenCookiesAreNull() throws ServletException, IOException {
+		// Given
+		given(request.getRequestURI()).willReturn("/api/some-endpoint");
+		given(request.getCookies()).willReturn(null);
+
+		// When
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+		// Then
+		then(jwtTokenService).should(never()).validateToken(any());
+		then(filterChain).should().doFilter(request, response);
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+
+	@Test
+	@DisplayName("쿠키 배열은 있지만 accessToken이 없으면 필터 체인을 그대로 통과한다")
+	void shouldPassFilterWhenAccessTokenCookieIsMissing() throws ServletException, IOException {
+		// Given
+		Cookie refreshCookie = new Cookie("refreshToken", "some.refresh.token");
+		given(request.getRequestURI()).willReturn("/api/some-endpoint");
+		given(request.getCookies()).willReturn(new Cookie[] {refreshCookie});
+
+		// When
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+		// Then
+		then(jwtTokenService).should(never()).validateToken(any());
+		then(filterChain).should().doFilter(request, response);
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+}

--- a/src/test/java/com/recorday/recorday/auth/local/service/LocalSecurityAuthServiceImplTest.java
+++ b/src/test/java/com/recorday/recorday/auth/local/service/LocalSecurityAuthServiceImplTest.java
@@ -1,7 +1,14 @@
 package com.recorday.recorday.auth.local.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,15 +25,17 @@ import org.springframework.security.core.Authentication;
 
 import com.recorday.recorday.auth.entity.CustomUserPrincipal;
 import com.recorday.recorday.auth.exception.AuthErrorCode;
-import com.recorday.recorday.auth.jwt.dto.TokenResponse;
 import com.recorday.recorday.auth.jwt.service.JwtTokenService;
 import com.recorday.recorday.auth.jwt.service.RefreshTokenService;
 import com.recorday.recorday.auth.local.dto.request.LocalLoginRequest;
-import com.recorday.recorday.auth.local.dto.response.AuthTokenResponse;
+import com.recorday.recorday.auth.local.dto.response.LoginResult;
 import com.recorday.recorday.auth.oauth2.enums.Provider;
+import com.recorday.recorday.auth.utils.CookieUtil;
 import com.recorday.recorday.exception.BusinessException;
 import com.recorday.recorday.user.entity.User;
 import com.recorday.recorday.user.enums.UserRole;
+import com.recorday.recorday.user.enums.UserStatus;
+import com.recorday.recorday.util.user.UserReader;
 
 @ExtendWith(MockitoExtension.class)
 class LocalSecurityAuthServiceImplTest {
@@ -39,88 +49,106 @@ class LocalSecurityAuthServiceImplTest {
 	@Mock
 	private RefreshTokenService refreshTokenService;
 
+	@Mock
+	private UserReader userReader;
+
+	@Mock
+	private CookieUtil cookieUtil;
+
 	@InjectMocks
 	private LocalSecurityLoginServiceImpl localSecurityAuthService;
 
 	private LocalLoginRequest request;
-	private CustomUserPrincipal principal;
-	private Authentication authentication;
+	private User user;
 
 	@BeforeEach
-	void setUp() throws Exception {
+	void setUp() {
 		String email = "test@example.com";
 		String rawPassword = "1234";
 
 		request = new LocalLoginRequest(email, rawPassword);
-		User user = createLocalUser(email);
-
-		principal = new CustomUserPrincipal(user);
-		authentication = new UsernamePasswordAuthenticationToken(
-			principal, null, principal.getAuthorities()
-		);
+		user = createLocalUser(email);
 	}
 
 	@Test
-	@DisplayName("Spring Security를 이용한 로그인 성공")
+	@DisplayName("로그인 성공 시 쿠키와 유저 상태를 포함한 결과를 반환한다")
 	void loginSuccess() {
-		//given
-		String email = "test@test.com";
-		String password = "password";
-		String publicId = "publicId";
-		LocalLoginRequest request = new LocalLoginRequest(email, password);
+		// given
+		String publicId = "user-public-id";
+		String accessToken = "new-access-token";
+		String refreshToken = "new-refresh-token";
 
-		// Authentication Mocking
+		// 1. Authentication & Principal Mocking
 		Authentication authentication = mock(Authentication.class);
 		CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
 
-		given(principal.getPublicId()).willReturn(publicId);
-		given(authentication.getPrincipal()).willReturn(principal);
-
 		given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
 			.willReturn(authentication);
+		given(authentication.getPrincipal()).willReturn(principal);
+		given(principal.getPublicId()).willReturn(publicId);
 
-		given(jwtTokenService.createAccessToken(publicId)).willReturn("access-token");
-		given(jwtTokenService.createRefreshToken(publicId)).willReturn("refresh-token");
+		// 2. UserReader Mocking (UserStatus 반환 확인용)
+		given(userReader.getUserByPublicId(publicId)).willReturn(user);
 
-		//when
-		TokenResponse response = localSecurityAuthService.login(request);
+		// 3. Token Generation Mocking
+		given(jwtTokenService.createAccessToken(publicId)).willReturn(accessToken);
+		given(jwtTokenService.createRefreshToken(publicId)).willReturn(refreshToken);
+		given(jwtTokenService.getAccessTokenValidityMillis()).willReturn(1000L);
+		given(jwtTokenService.getRefreshTokenValidityMillis()).willReturn(2000L);
 
-		//then
-		assertThat(response.accessToken()).isEqualTo("access-token");
-		assertThat(response.refreshToken()).isEqualTo("refresh-token");
+		// 4. CookieUtil Mocking
+		ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken).build();
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken).build();
 
-		then(authenticationManager).should().authenticate(any(UsernamePasswordAuthenticationToken.class));
-		then(jwtTokenService).should().createAccessToken(publicId);
-		then(jwtTokenService).should().createRefreshToken(publicId);
-		then(refreshTokenService).should().saveRefreshToken(publicId, "refresh-token");
+		given(cookieUtil.createTokenCookie(eq("accessToken"), eq(accessToken), anyLong()))
+			.willReturn(accessCookie);
+		given(cookieUtil.createTokenCookie(eq("refreshToken"), eq(refreshToken), anyLong()))
+			.willReturn(refreshCookie);
+
+		// when
+		LoginResult result = localSecurityAuthService.login(request);
+
+		// then
+		// 1. Redis 저장 호출 검증
+		then(refreshTokenService).should().saveRefreshToken(publicId, refreshToken);
+
+		// 2. 반환 값(UserStatus) 검증
+		assertThat(result.userStatus()).isEqualTo(UserStatus.ACTIVE);
+
+		// 3. 반환 값(Cookies) 검증
+		assertThat(result.cookies().accessTokenCookie().getValue()).isEqualTo(accessToken);
+		assertThat(result.cookies().refreshTokenCookie().getValue()).isEqualTo(refreshToken);
 	}
 
 	@Test
-	@DisplayName("인증 실패 시 예외 발생")
+	@DisplayName("비밀번호 불일치(BadCredentials) 시 BusinessException(INVALID_CREDENTIALS) 발생")
 	void loginFail_badCredentials() {
-		//given
+		// given
 		given(authenticationManager.authenticate(any(Authentication.class)))
 			.willThrow(new BadCredentialsException("bad credentials"));
 
-		//then
+		// when & then
 		assertThatThrownBy(() -> localSecurityAuthService.login(request))
 			.isInstanceOf(BusinessException.class)
-			.hasFieldOrPropertyWithValue("errorCode", AuthErrorCode.INVALID_CREDENTIALS);
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
 
-		then(authenticationManager).should().authenticate(any(Authentication.class));
 		then(jwtTokenService).shouldHaveNoInteractions();
+		then(refreshTokenService).shouldHaveNoInteractions();
 	}
 
+	// Helper Method
 	private User createLocalUser(String email) {
 		return User.builder()
 			.id(1L)
+			.publicId("user-public-id")
 			.provider(Provider.RECORDAY)
 			.userRole(UserRole.ROLE_USER)
+			.userStatus(UserStatus.ACTIVE) // 상태 명시
 			.email(email)
 			.password("encoded")
 			.username("테스트 유저")
 			.profileUrl("resources/defaults/userDefaultImage.png")
 			.build();
 	}
-  
 }

--- a/src/test/java/com/recorday/recorday/auth/local/service/LocalSecurityLoginServiceImplTest.java
+++ b/src/test/java/com/recorday/recorday/auth/local/service/LocalSecurityLoginServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.recorday.recorday.auth.local.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.recorday.recorday.auth.entity.CustomUserPrincipal;
+import com.recorday.recorday.auth.exception.AuthErrorCode;
+import com.recorday.recorday.auth.jwt.service.JwtTokenService;
+import com.recorday.recorday.auth.jwt.service.RefreshTokenService;
+import com.recorday.recorday.auth.local.dto.request.LocalLoginRequest;
+import com.recorday.recorday.auth.local.dto.response.LoginResult;
+import com.recorday.recorday.exception.BusinessException;
+import com.recorday.recorday.user.entity.User;
+import com.recorday.recorday.user.enums.UserStatus;
+import com.recorday.recorday.util.user.UserReader;
+
+@ExtendWith(MockitoExtension.class)
+class LocalSecurityLoginServiceImplTest {
+
+	@InjectMocks
+	private LocalSecurityLoginServiceImpl localLoginService;
+
+	@Mock
+	private UserReader userReader;
+	@Mock
+	private AuthenticationManager authenticationManager;
+	@Mock
+	private JwtTokenService jwtTokenService;
+	@Mock
+	private RefreshTokenService refreshTokenService;
+
+	@Mock
+	private Authentication authentication;
+	@Mock
+	private CustomUserPrincipal principal;
+	@Mock
+	private User user;
+
+	private final long ACCESS_EXPIRATION = 1800000L;
+	private final long REFRESH_EXPIRATION = 604800000L;
+
+	@BeforeEach
+	void setUp() {
+		// @Value 필드 주입
+		ReflectionTestUtils.setField(localLoginService, "accessValidity", ACCESS_EXPIRATION);
+		ReflectionTestUtils.setField(localLoginService, "refreshValidity", REFRESH_EXPIRATION);
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 쿠키와 유저 상태를 포함한 결과를 반환한다")
+	void login_success() {
+		// Given
+		LocalLoginRequest request = new LocalLoginRequest("test@email.com", "password");
+		String publicId = "user-public-id";
+		String accessToken = "access-token";
+		String refreshToken = "refresh-token";
+
+		// Authentication 모킹
+		given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+			.willReturn(authentication);
+		given(authentication.getPrincipal()).willReturn(principal);
+		given(principal.getPublicId()).willReturn(publicId);
+
+		// User 조회 모킹
+		given(userReader.getUserByPublicId(publicId)).willReturn(user);
+		given(user.getUserStatus()).willReturn(UserStatus.ACTIVE);
+
+		// 토큰 생성 모킹
+		given(jwtTokenService.createAccessToken(publicId)).willReturn(accessToken);
+		given(jwtTokenService.createRefreshToken(publicId)).willReturn(refreshToken);
+
+		// When
+		LoginResult result = localLoginService.login(request);
+
+		// Then
+		// 1. Refresh Token 저장 호출 확인
+		then(refreshTokenService).should().saveRefreshToken(publicId, refreshToken);
+
+		// 2. 반환된 UserStatus 확인
+		assertThat(result.userStatus()).isEqualTo(com.recorday.recorday.user.enums.UserStatus.ACTIVE);
+
+		// 3. Access Token 쿠키 검증
+		assertThat(result.cookies().accessTokenCookie().getValue()).isEqualTo(accessToken);
+		assertThat(result.cookies().accessTokenCookie().getMaxAge()).isEqualTo(Duration.ofMillis(ACCESS_EXPIRATION));
+		assertThat(result.cookies().accessTokenCookie().isHttpOnly()).isTrue();
+		assertThat(result.cookies().accessTokenCookie().isSecure()).isTrue();
+
+		// 4. Refresh Token 쿠키 검증
+		assertThat(result.cookies().refreshTokenCookie().getValue()).isEqualTo(refreshToken);
+		assertThat(result.cookies().refreshTokenCookie().getMaxAge()).isEqualTo(Duration.ofMillis(REFRESH_EXPIRATION));
+		assertThat(result.cookies().refreshTokenCookie().isHttpOnly()).isTrue();
+	}
+
+	@Test
+	@DisplayName("비밀번호 불일치 시 BadCredentialsException을 BusinessException으로 변환한다")
+	void login_fail_badCredentials() {
+		// Given
+		LocalLoginRequest request = new LocalLoginRequest("test@email.com", "wrong-password");
+
+		given(authenticationManager.authenticate(any()))
+			.willThrow(new BadCredentialsException("Bad credentials"));
+
+		// When & Then
+		BusinessException ex = assertThrows(BusinessException.class,
+			() -> localLoginService.login(request));
+
+		assertThat(ex.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+
+		// 토큰 생성 로직이 실행되지 않았는지 확인
+		then(jwtTokenService).shouldHaveNoInteractions();
+	}
+}

--- a/src/test/java/com/recorday/recorday/frame/repository/FrameRepositoryTest.java
+++ b/src/test/java/com/recorday/recorday/frame/repository/FrameRepositoryTest.java
@@ -51,14 +51,14 @@ class FrameRepositoryTest {
 		FrameComponent comp1 = FrameComponent.builder()
 			.type(ComponentType.TEXT)
 			.source("Happy Day") // 텍스트 내용
-			.x(10).y(20).width(200).height(50) // 필수 좌표
+			.x(10).y(20).width(200.0).height(50.0) // 필수 좌표
 			.rotation(0).zIndex(1)
 			.build();
 
 		FrameComponent comp2 = FrameComponent.builder()
 			.type(ComponentType.PHOTO)
 			.source("https://s3.../img.jpg") // 이미지 URL
-			.x(50).y(60).width(300).height(400)
+			.x(50).y(60).width(300.0).height(400.0)
 			.rotation(15).zIndex(2)
 			.build();
 
@@ -118,9 +118,8 @@ class FrameRepositoryTest {
 		return Frame.builder()
 			.title(name)
 			.description(description)
-			.source("https://s3.../img.jpg")
+			.previewKey("https://s3.../img.jpg")
 			.frameType(FrameType.CLASSIC)
-			.canvasWidth(800).canvasHeight(1200)
 			.background(new ColorBackgroundAttributes("#FFFFFF"))
 			.build();
 	}


### PR DESCRIPTION
- 인증 쿠키 정보를 캡슐화하기 위한 `AuthTokenCookies` record 도입
- 보안 속성이 표준화된 쿠키 생성을 단순화하기 위해 `CookieUtil` 추가
- `LocalSecurityLoginServiceImpl`에서 쿠키와 사용자 상태를 함께 반환하는 `LoginResult` 도입
- `JwtAuthenticationFilter`가 헤더 대신 쿠키 기반 Access Token을 처리하도록 리팩토링
- 응답 유틸리티를 개선하여 쿠키 기반 토큰 헤더를 함께 포함할 수 있도록 확장
- 쿠키 기반 인증 시나리오를 검증하기 위한 관련 단위 테스트 보강